### PR TITLE
feat(vm): implement supplemental page table init and page operations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "jungle ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jungle
 USER jungle
 WORKDIR /home/jungle
 
-RUN echo "source /workspaces/week09/pintos/activate" >> /home/jungle/.bashrc
+RUN echo "source /workspaces/JunglePintos-VirtualMemory/pintos/activate" >> /home/jungle/.bashrc
 
 # Clone the repository
 # RUN git clone https://github.com/casys-kaist/pintos-kaist /home/jungle/pintos

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,7 +68,10 @@
     "mmu.h": "c",
     "vaddr.h": "c",
     "off_t.h": "c",
-    "debug.h": "c"
+    "debug.h": "c",
+    "malloc.h": "c",
+    "vm.h": "c",
+    "inspect.h": "c"
   },
   "C_Cpp.errorSquiggles": "disabled",
 }

--- a/pintos/include/lib/kernel/hash.h
+++ b/pintos/include/lib/kernel/hash.h
@@ -46,9 +46,7 @@ typedef uint64_t hash_hash_func (const struct hash_elem *e, void *aux);
 /* Compares the value of two hash elements A and B, given
  * auxiliary data AUX.  Returns true if A is less than B, or
  * false if A is greater than or equal to B. */
-typedef bool hash_less_func (const struct hash_elem *a,
-		const struct hash_elem *b,
-		void *aux);
+typedef bool hash_less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux);
 
 /* Performs some operation on hash element E, given auxiliary
  * data AUX. */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "lib/kernel/hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -46,6 +47,9 @@ struct page {
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
+	/* ?? */
+	bool is_writable;
+	struct hash_elem hash_e;
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -85,6 +89,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash h_table;
 };
 
 #include "threads/thread.h"

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -22,8 +22,7 @@ static void rehash (struct hash *);
 /* Initializes hash table H to compute hash values using HASH and
    compare hash elements using LESS, given auxiliary data AUX. */
 bool
-hash_init (struct hash *h,
-		hash_hash_func *hash, hash_less_func *less, void *aux) {
+hash_init (struct hash *h, hash_hash_func *hash, hash_less_func *less, void *aux) {
 	h->elem_cnt = 0;
 	h->bucket_cnt = 4;
 	h->buckets = malloc (sizeof *h->buckets * h->bucket_cnt);

--- a/pintos/threads/mmu.c
+++ b/pintos/threads/mmu.c
@@ -228,8 +228,8 @@ If WRITABLE is true, the new page is read/write, otherwise it is read-only.
 Returns true if successful, false if memory allocation failed.
 🔥 edward
 pml4: address of destination page table (user)
-upage: virtual address for a destination page table (user)
-kpage: virtual address for a origin page table (kernel)
+upage: user virtual address (not mapped)
+kpage: kernel virtual address (mapped)
 rw: boolean value which tells if the page is writable or not
 */
 bool

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -593,7 +593,7 @@ load (const char *file_name, struct intr_frame *if_) {
 			goto done;
 		file_seek (file, file_ofs);
 
-		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr)
+		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr) /* edward: read program header from ELF file */
 			goto done;
 		file_ofs += sizeof phdr;
 		switch (phdr.p_type) {


### PR DESCRIPTION
- add `supplemental_page_table_init` for initializing per-process SPT
- implement `spt_find_page` to lookup pages by virtual address
- implement `spt_insert_page` to register new pages into SPT
- maintain internal data structures for page management consistency