### PR TITLE
[P3-vm] Implement SPT copy/kill and reinitialize SPT on exec

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -359,6 +359,9 @@ process_exec (void *f_name) {
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
 	process_cleanup (); /* We first kill the current context */
+#ifdef VM
+	supplemental_page_table_init(&thread_current()->spt);
+#endif
 	success = load (file_name, &_if); /* And then load the binary */
 	/* test 46 fails.. */
 	palloc_free_page (file_name);


### PR DESCRIPTION
Implements SPT clone/kill for fork() and reinitializes the SPT on exec(), completing the core VM support for userprog.

## Tests
- [x]  fork-*
- [x]  exec-*
- [x]  wait-*
- [x]  multi-*
- [x]  rox-*
- [x]  bad-*

## Refs
#35 