### PR TITLE
Refactor stack growth logic and unify cleanup with user rsp tracking and buffer validation

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -109,15 +109,14 @@ struct thread {
   - elem_donator: thread_remove_lock_donations
   - elem_integrated: thread_exit
   */
-  struct list_elem
-      elem_default; /* edward: ready_list + sleep_list + waiters (semaphore) */
-  struct list_elem
-      elem_donator; /* edward: exclusively for the "struct list donators" */
+  struct list_elem elem_default; /* edward: ready_list + sleep_list + waiters (semaphore) */
+  struct list_elem elem_donator; /* edward: exclusively for the "struct list donators" */
   struct list_elem elem_integrated; /* edward: used for mlfqs */
   int64_t wakeup_tick;
   int stdin_cnt, stdout_cnt;
-
-#ifdef USERPROG
+  struct file *running_file;
+  
+  #ifdef USERPROG
   /* Owned by userprog/process.c. */
   uint64_t *pml4;                /* Page map level 4 */
   struct list file_descriptors;  /* Open file descriptors. */
@@ -126,7 +125,6 @@ struct thread {
   struct list children;          /* Child wait statuses. */
   bool children_initialized;     /* Tracks list initialization. */
   struct sync_to_parent *sync2p; /* Synchronization with parent. */
-  struct file *running_file;
 #endif
 #ifdef VM
   /* Table for whole virtual memory owned by thread. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -129,6 +129,7 @@ struct thread {
 #ifdef VM
   /* Table for whole virtual memory owned by thread. */
   struct supplemental_page_table spt;
+  uintptr_t user_rsp;
 #endif
 
   /* Owned by thread.c. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -319,6 +319,7 @@ __do_fork (void *aux) {
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL) goto error;
 	process_activate (current);
+	thread_current()->running_file = file_duplicate(parent->running_file);
 #ifdef VM
 	supplemental_page_table_init (&current->spt);
 	if (!supplemental_page_table_copy (&current->spt, &parent->spt)) goto error;
@@ -357,6 +358,10 @@ process_exec (void *f_name) {
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
+	if (thread_current()->running_file) {
+		file_close(thread_current()->running_file);
+		thread_current()->running_file = NULL;
+	}
 	process_cleanup (); /* We first kill the current context */
 #ifdef VM
 	supplemental_page_table_init(&thread_current()->spt);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -358,10 +358,6 @@ process_exec (void *f_name) {
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	if (thread_current()->running_file) {
-		file_close(thread_current()->running_file);
-		thread_current()->running_file = NULL;
-	}
 	process_cleanup (); /* We first kill the current context */
 #ifdef VM
 	supplemental_page_table_init(&thread_current()->spt);
@@ -427,11 +423,7 @@ process_exit (void) {
 		wait_status_release (curr->sync2p);
 		curr->sync2p = NULL;
 	}
-	if (curr->running_file) {
-		file_allow_write(curr->running_file);
-		file_close(curr->running_file);
-		curr->running_file = NULL;
-	}
+
 	syscall_process_cleanup();
 	process_cleanup ();
 }
@@ -443,6 +435,12 @@ edward: destroy page table
 static void
 process_cleanup (void) {
 	struct thread *curr = thread_current ();
+	
+	if (curr->running_file) {
+		// file_allow_write(curr->running_file);
+		file_close(curr->running_file);
+		curr->running_file = NULL;
+	}
 
 #ifdef VM
 	supplemental_page_table_kill (&curr->spt);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -42,7 +42,7 @@ static struct lock filesys_lock;
 static void halt_handler (void) NO_RETURN;
 static void exit_handler (int status) NO_RETURN;
 static void exit_with_error (void) NO_RETURN;
-static void validate_user_buffer (const void *buffer, size_t size);
+static void validate_user_buffer (const void *buffer, size_t size, bool writable);
 static void validate_user_string (const char *str);
 static char *copy_user_string (const char *str);
 static struct file_descriptor *fd_lookup (int fd);
@@ -140,15 +140,12 @@ int
 write_handler (int fd, const void *buffer, unsigned length) {
 	if (fd < 0) return -1;
 	if (length == 0) return 0;
-	validate_user_buffer (buffer, length);
-
-	// if (fd == STDOUT_FILENO) {
-	// 	putbuf (buffer, length);
-	// 	return (int) length;
-	// }
-	// if (fd == STDIN_FILENO) return -1;
 	
 	struct file_descriptor *desc = fd_lookup (fd);
+	if (desc->file) {
+		validate_user_buffer (buffer, length, desc->file->deny_write);
+	}
+	
 	if (!desc) return -1;
 	if (!desc->file) { /* STDIN, STDOUT */
 		if (desc->fd_kind == FD_STDIN) return -1;
@@ -170,7 +167,7 @@ read_handler (int fd, void *buffer, unsigned length) {
 	if (length == 0) return 0;
 	// printf("💻 entered read_handler\n");
 	// printf("👀 before validate_user_buffer\n");
-	validate_user_buffer (buffer, length);
+	validate_user_buffer (buffer, length, true);
 	// printf("👀 after validate_user_buffer\n");
 
 	// if (fd == STDIN_FILENO) {
@@ -218,20 +215,24 @@ exit_with_error (void) {
 }
 
 static void
-validate_user_buffer (const void *buffer, size_t size) {
+validate_user_buffer (const void *buffer, size_t size, bool writable) {
 	const uint8_t *ptr = buffer;
+	struct page *tmp_page = NULL;
+
 	// printf("✅ entered validate user buffer\n");
 	for (size_t i = 0; i < size; i++) {
+		tmp_page = spt_find_page(&thread_current()->spt, ptr + i);
 		if (!is_user_vaddr (ptr + i)) {
 			exit_with_error();
 		}
-		else if(!spt_find_page(&thread_current()->spt, ptr + i)) {
+		if(!tmp_page) {
 			if (thread_current()->user_rsp - 8 <= ptr + i && ptr + i <= USER_STACK) {
 				continue;
 			}
-			else {
-				exit_with_error();
-			}
+			exit_with_error();
+		}
+		if (!tmp_page->writable && writable) {
+			exit_with_error();
 		}
 	}
 	// printf("❌ exits validate user buffer\n");
@@ -242,7 +243,7 @@ validate_user_string (const char *str) {
 	if (str == NULL)
 		exit_with_error ();
 	while (true) {
-		validate_user_buffer (str, 1);
+		validate_user_buffer (str, 1, false);
 		if (*str == '\0') break;
 		str++;
 	}

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -10,6 +10,7 @@
 
 #include "vm/vm.h"
 #include "vm/uninit.h"
+#include "userprog/process.h"
 
 static bool uninit_initialize (struct page *page, void *kva);
 static void uninit_destroy (struct page *page);
@@ -60,6 +61,7 @@ uninit_initialize (struct page *page, void *kva) {
 static void
 uninit_destroy (struct page *page) {
   struct uninit_page *uninit = &page->uninit;
-  /* TODO: Fill this function.
-   * TODO: If you don't have anything to do, just return. */
+  if (uninit->aux) {
+    free(uninit->aux);
+  }
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -172,6 +172,7 @@ vm_get_frame (void) {
 
 /* Growing the stack. */
 static void vm_stack_growth(void *addr) {
+  // printf("✅ entered vm_stack_growth\n");
   ASSERT(!spt_find_page(&thread_current()->spt, pg_round_down(addr)));
   if (USER_STACK - STACK_LIMIT > pg_round_down(addr)) {
     return;
@@ -198,7 +199,10 @@ vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bo
   
   /* TODO: Your code goes here */
   if (!page) {
-    void *rsp = user ? f->rsp : thread_current()->tf.rsp;
+    void *rsp = user ? f->rsp : thread_current()->user_rsp;
+    // printf("😡 user_rsp: %x\n", thread_current()->user_rsp);
+    // printf("😡 f->rsp: %x\n", f->rsp);
+    // printf("😡 tf.rsp: %x\n", thread_current()->tf.rsp);
     if (rsp - 8 <= addr && addr <= USER_STACK) {
       vm_stack_growth(addr);
       page = spt_find_page(spt, pg_round_down(addr));


### PR DESCRIPTION
### Overview  
This pull request refactors the virtual memory stack growth implementation and unifies process cleanup logic while adding support for tracking the user's stack pointer (rsp) and improving syscall buffer validation.  
  
### Key Changes  
- Split stack growth logic into clearer functions and fixed auxiliary data cloning behavior during process forking.  
- Unified the handling of `running_file` cleanup into `process_cleanup` to ensure consistent resource management.  
- Added tracking of the user-mode rsp in the thread structure and refined stack-growth validation logic to prevent improper stack expansion.  
- Updated `validate_user_buffer` in the syscall layer to check writability in the page table when validating buffers passed from user space.  
  
These changes improve the reliability of user stack growth, reduce duplication in cleanup code, and enhance the safety of system call buffer handling.
