### PR TITLE
fix(vm): ensure locking on file_read_at in lazy_load_segment and add …

### DIFF
--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <list.h>
+#include "threads/synch.h"
 
 struct thread;
 struct file;
@@ -20,5 +21,6 @@ void syscall_init (void);
 int write_handler (int fd, const void *buffer, unsigned length);
 void syscall_process_cleanup (void);
 bool syscall_duplicate_fds (struct thread *parent, struct thread *child);
+extern struct lock filesys_lock;
 
 #endif /* userprog/syscall.h */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -857,7 +857,11 @@ lazy_load_segment (struct page *page, void *aux) {
 	/* TODO: This called when the first page fault occurs on address VA. */
 	void *kva = page->frame->kva;
 
-	if (file_read_at (load_aux ->file, kva, load_aux ->read_bytes, load_aux ->ofs) != (int) load_aux ->read_bytes) {
+	lock_acquire (&filesys_lock);
+	int bytes_read = file_read_at (load_aux ->file, kva, load_aux ->read_bytes, load_aux ->ofs);
+	lock_release (&filesys_lock);
+
+	if (bytes_read != (int) load_aux ->read_bytes) {
 		free (load_aux);
 		return false;
 	}


### PR DESCRIPTION
…user buffer mapping

- guard file_read_at calls in lazy_load_segment with proper lock to prevent race conditions
- introduce get_user/put_user in validate_user_buffer to trigger mapping and safely access user memory
- improve robustness of lazy loading and user buffer validation paths